### PR TITLE
fix: gate the Companion internal_url banner on the Companion being the active renderer

### DIFF
--- a/.github/scripts/shizuku-adb-start.sh
+++ b/.github/scripts/shizuku-adb-start.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Start the Shizuku server on the connected emulator over adb.
+# Shizuku v13.6.0 no longer exports a start.sh to external storage; its
+# Starter.adbCommand is exactly "adb shell <nativeLibraryDir>/libshizuku.so",
+# so this resolves the installed APK's native lib dir and runs the starter.
+# The emulator-runner action runs each workflow script line in a separate
+# shell, so this whole flow lives in one file.
+set -eu
+
+PKG=moe.shizuku.privileged.api
+
+apk=$(adb shell pm path "$PKG" | sed -n 's/^package://p' | head -n 1 | tr -d '\r')
+if [ -z "$apk" ]; then
+  echo "::error::Shizuku manager package is not installed"
+  exit 1
+fi
+appdir=${apk%/*}
+abi=$(adb shell ls "$appdir/lib/" | head -n 1 | tr -d '\r')
+starter="$appdir/lib/$abi/libshizuku.so"
+
+echo "Starting Shizuku via $starter"
+adb shell "$starter" || echo "starter exited with status $?"
+
+started=0
+i=0
+while [ "$i" -lt 30 ]; do
+  if adb shell ps -A 2>/dev/null | grep -q shizuku_server; then
+    started=1
+    break
+  fi
+  i=$((i + 1))
+  sleep 1
+done
+
+if [ "$started" != 1 ]; then
+  echo "::error::shizuku_server did not start"
+  echo '--- starter binary ---'
+  adb shell ls -la "$appdir/lib/$abi/" || true
+  echo '--- processes ---'
+  adb shell ps -A 2>/dev/null | grep -i shizuku || true
+  echo '--- logcat (shizuku / crashes) ---'
+  adb logcat -d | grep -iE 'shizuku|AndroidRuntime' | tail -n 120 || true
+  exit 1
+fi
+
+echo "shizuku_server is running"

--- a/.github/scripts/shizuku-emulator-suite.sh
+++ b/.github/scripts/shizuku-emulator-suite.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Full Shizuku emulator exercise: install the manager, start its server,
+# install the app and instrumentation APKs, and run the integration test.
+# Lives in one file because the emulator-runner action executes each
+# workflow script line in a separate shell.
+set -eu
+
+SHIZUKU_APK="${1:?usage: shizuku-emulator-suite.sh <shizuku.apk>}"
+APP_PKG=io.github.maxlyth.hapaneld
+
+# Streamed adb install reliably wedges on the API 27 image from the second
+# install onward (the first always succeeds, later ones hang until the job
+# timeout, surviving adb server restarts). Bypass the streamed path: push
+# the APK and run pm install on-device, bounded and retried once.
+adb_install() {
+  base=$(basename "$1")
+  timeout 120 adb push "$1" "/data/local/tmp/$base" < /dev/null
+  if ! pm_install_once "$base"; then
+    echo "pm install $base failed or timed out; restarting adb and retrying"
+    adb kill-server || true
+    adb start-server
+    adb wait-for-device
+    pm_install_once "$base"
+  fi
+  adb shell rm -f "/data/local/tmp/$base" < /dev/null || true
+}
+
+pm_install_once() {
+  out=$(timeout 300 adb shell pm install -r -t "/data/local/tmp/$1" < /dev/null) || return 1
+  printf '%s\n' "$out"
+  case "$out" in
+    *Success*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Install everything before starting the Shizuku server: on API 27 the
+# running server reliably wedges any subsequent pm install session, while
+# ordinary shell commands and instrumentation keep working.
+adb_install "$SHIZUKU_APK"
+adb_install app/build/outputs/apk/debug/app-debug.apk
+adb_install app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
+adb push "$SHIZUKU_APK" /data/local/tmp/shizuku.apk
+# A freshly installed app has no files/ dir until first launch; create it
+# before copying the manager APK into the app's private storage.
+adb shell run-as "$APP_PKG" mkdir -p files
+adb shell run-as "$APP_PKG" cp /data/local/tmp/shizuku.apk files/shizuku-test.apk
+
+sh "$(dirname "$0")/shizuku-adb-start.sh"
+timeout 30 adb shell echo device-responsive || echo "::warning::device shell unresponsive after Shizuku start"
+
+adb shell am instrument -w \
+  -e managerApk "/data/user/0/$APP_PKG/files/shizuku-test.apk" \
+  -e class io.github.maxlyth.hapaneld.shizuku.ShizukuIntegrationTest \
+  "$APP_PKG.test/androidx.test.runner.AndroidJUnitRunner"

--- a/.github/workflows/shizuku-emulator.yml
+++ b/.github/workflows/shizuku-emulator.yml
@@ -36,7 +36,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [27, 35]
+        # The app APK only ships 64-bit native libraries, so every image must
+        # be x86_64. android-27 google_apis was never published for x86_64,
+        # which forces the default (AOSP) image there; that is fine because
+        # Shizuku is started via its libshizuku.so starter binary directly and
+        # no longer depends on the manager exporting start.sh.
+        include:
+          - api-level: 27
+            target: default
+            arch: x86_64
+          - api-level: 35
+            target: google_apis
+            arch: x86_64
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -53,7 +64,7 @@ jobs:
           cache-provider: basic
 
       - name: Install build SDK, NDK, and emulator image
-        run: sdkmanager "platform-tools" "platforms;android-35" "system-images;android-${{ matrix.api-level }};default;x86_64" "ndk;27.0.12077973" "cmake;3.22.1"
+        run: sdkmanager "platform-tools" "platforms;android-35" "system-images;android-${{ matrix.api-level }};${{ matrix.target }};${{ matrix.arch }}" "ndk;27.0.12077973" "cmake;3.22.1"
 
       - name: Download curated Shizuku manager
         run: |
@@ -75,17 +86,8 @@ jobs:
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
         with:
           api-level: ${{ matrix.api-level }}
-          target: default
-          arch: x86_64
+          target: ${{ matrix.target }}
+          arch: ${{ matrix.arch }}
           profile: pixel_2
           disable-animations: true
-          script: |
-            adb install "$RUNNER_TEMP/shizuku.apk"
-            adb shell monkey -p moe.shizuku.privileged.api 1
-            for i in $(seq 1 20); do adb shell test -f /storage/emulated/0/Android/data/moe.shizuku.privileged.api/start.sh && break; sleep 1; done
-            adb shell sh /storage/emulated/0/Android/data/moe.shizuku.privileged.api/start.sh
-            adb install app/build/outputs/apk/debug/app-debug.apk
-            adb push "$RUNNER_TEMP/shizuku.apk" /data/local/tmp/shizuku.apk
-            adb shell run-as io.github.maxlyth.hapaneld cp /data/local/tmp/shizuku.apk files/shizuku-test.apk
-            adb install app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
-            adb shell am instrument -w -e managerApk /data/user/0/io.github.maxlyth.hapaneld/files/shizuku-test.apk -e class io.github.maxlyth.hapaneld.shizuku.ShizukuIntegrationTest io.github.maxlyth.hapaneld.test/androidx.test.runner.AndroidJUnitRunner
+          script: sh .github/scripts/shizuku-emulator-suite.sh "$RUNNER_TEMP/shizuku.apk"

--- a/app/src/main/kotlin/io/github/maxlyth/hapaneld/control/CompanionDb.kt
+++ b/app/src/main/kotlin/io/github/maxlyth/hapaneld/control/CompanionDb.kt
@@ -53,6 +53,14 @@ object CompanionDb {
     /** A row needs repair when its internal URL is blank but a usable external URL exists to copy. */
     fun needsRepair(r: ServerRow): Boolean = isBlank(r.internalUrl) && !isBlank(r.externalUrl)
 
+    /** Whether the internal-URL health warning applies: only when the Companion is the app that will
+     *  actually render the dashboard — an explicitly configured Companion `dashboard_package`, or a
+     *  blank one (auto-detect prefers the Companion when installed). With the built-in renderer or
+     *  another explicit dashboard app a blank `internal_url` can't blank the panel (the built-in
+     *  renderer's login borrow already falls back to `external_url`), so the warning stays quiet. */
+    fun warningApplies(dashboardPackage: String): Boolean =
+        dashboardPackage.isBlank() || dashboardPackage in CompanionInstaller.SUPPORTED_PACKAGES
+
     /** Parse the `id US internal US external` lines emitted by [DUMP_SQL]. Tolerant of blank lines and
      *  short rows (a missing trailing field → ""). A line with no id is skipped. */
     fun parseServers(output: String): List<ServerRow> =

--- a/app/src/main/kotlin/io/github/maxlyth/hapaneld/http/PaneldServer.kt
+++ b/app/src/main/kotlin/io/github/maxlyth/hapaneld/http/PaneldServer.kt
@@ -1919,7 +1919,7 @@ publishes MQTT availability, so the discovery hooks are in place.</p>
                 "Reinstall or downgrade the dashboard/Companion app, or reboot the panel.",
         )
         companionUrlCache.get().let { u ->
-            if (u.needsRepair) warns.add(
+            if (u.needsRepair && CompanionDb.warningApplies(config.dashboardPackage)) warns.add(
                 "⚠ <b>Home Assistant Companion has no internal URL</b> (${u.affected} server${if (u.affected == 1) "" else "s"}) — " +
                     "the dashboard can fail with \"Missing 'Host' header\". Repair it on the Install tab.",
             )
@@ -2200,7 +2200,8 @@ publishes MQTT availability, so the discovery hooks are in place.</p>
     }
 
     /** Render-blocking warnings not modelled by HealthAudit: a crash-looping dashboard app, and a Companion
-     *  server row with a blank internal_url (HA 2026.7 "Missing 'Host' header"). Shown on BOTH the dashboard
+     *  server row with a blank internal_url (HA 2026.7 "Missing 'Host' header") — the latter only when the
+     *  Companion is the active renderer ([CompanionDb.warningApplies]). Shown on BOTH the dashboard
      *  banner and the Install tab as high-severity (`crit`). [inlineRepair] adds the one-tap repair button
      *  (Install tab, where install.js is loaded); the dashboard links to the Install tab for the action. */
     private fun adHocWarnings(inlineRepair: Boolean): String = buildString {
@@ -2224,7 +2225,7 @@ publishes MQTT availability, so the discovery hooks are in place.</p>
                 """downgrade the dashboard/Companion app (see <a href="/install">updates</a>), or reboot the panel.</div>""",
         )
         companionUrlCache.get().let { u ->
-            if (u.needsRepair) {
+            if (u.needsRepair && CompanionDb.warningApplies(config.dashboardPackage)) {
                 val action = if (inlineRepair)
                     """<div style="margin-top:10px"><button class="pbtn" onclick="repairCompUrl(this)">⚙ Repair internal URL</button> <span id="cu-fix" class="muted"></span></div>"""
                 else """ <a href="/install">Repair on the Install tab →</a>"""

--- a/app/src/test/kotlin/io/github/maxlyth/hapaneld/control/CompanionDbTest.kt
+++ b/app/src/test/kotlin/io/github/maxlyth/hapaneld/control/CompanionDbTest.kt
@@ -44,6 +44,16 @@ class CompanionDbTest {
         assertFalse(CompanionDb.needsRepair(CompanionDb.ServerRow("1", "http://10.0.0.5:8123", "https://ha")))
     }
 
+    @Test fun internalUrlWarningOnlyWhenCompanionRendersTheDashboard() {
+        // Blank dashboard_package = auto-detect, which prefers the Companion when installed.
+        assertTrue(CompanionDb.warningApplies(""))
+        assertTrue(CompanionDb.warningApplies(io.github.maxlyth.hapaneld.util.CompanionInstaller.FULL_PKG))
+        assertTrue(CompanionDb.warningApplies(io.github.maxlyth.hapaneld.util.CompanionInstaller.MINIMAL_PKG))
+        // Built-in renderer or another explicit dashboard app: the Companion doesn't draw, so no banner.
+        assertFalse(CompanionDb.warningApplies(SystemController.BUILTIN_DASHBOARD))
+        assertFalse(CompanionDb.warningApplies("de.ozerov.fully"))
+    }
+
     @Test fun urlsWithPipesSurviveParsing() {
         // The default sqlite3 '|' separator would corrupt this; the Unit-Separator dump doesn't.
         val out = line("1", "http://h/a|b", "https://ha/x|y")


### PR DESCRIPTION
## Problem

The red **"Home Assistant Companion has no internal URL"** banner fires purely on *root available + Companion installed + a `servers` row with a blank `internal_url`*. It never consults `dashboard_package`, so panels running the **built-in renderer** (e.g. nsp2) show a crit warning about a failure mode that cannot affect them:

- The "Missing 'Host' header" failure is Companion-specific — it happens when the Companion's WebView requests a host-less URL. The built-in renderer never uses the Companion's `internal_url` selection logic.
- The built-in renderer's login borrow already falls back cleanly to `external_url` when `internal_url` is blank (`LoginRow.url`).

Contrast: the dashboard-zoom warning a few lines below already gates on `config.dashboardPackage == BUILTIN_DASHBOARD`.

## Fix

New pure predicate `CompanionDb.warningApplies(dashboardPackage)`: the warning applies only when the Companion is the app that will actually render the dashboard — an explicitly configured Companion package, or a blank `dashboard_package` (auto-detect, which `resolveDashboard("")` resolves to the Companion when installed). Both surfaces are gated:

- the dashboard banner / Install-tab warning (`adHocWarnings`)
- the `/api/v1/status` warnings list (`statusJson`)

The gate reads live config, so switching the renderer takes effect immediately (no cache-TTL lag); the underlying DB health check and one-tap repair are unchanged and re-surface if the panel is ever switched back to the Companion.

## Testing

- `CompanionDbTest` extended with `internalUrlWarningOnlyWhenCompanionRendersTheDashboard` (blank / full / minimal Companion → warn; `builtin` / Fully Kiosk → quiet).
- `:app:testDebugUnitTest --tests ...CompanionDbTest` passes locally (NDK asset tasks skipped on macOS).

