### PR TITLE
ci: run android instrumentation am instrument on a single line

### DIFF
--- a/.github/workflows/android-instrumentation.yml
+++ b/.github/workflows/android-instrumentation.yml
@@ -57,6 +57,4 @@ jobs:
           script: |
             adb install app/build/outputs/apk/debug/app-debug.apk
             adb install app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
-            adb shell am instrument -w \
-              -e notClass io.github.maxlyth.hapaneld.shizuku.ShizukuIntegrationTest \
-              io.github.maxlyth.hapaneld.test/androidx.test.runner.AndroidJUnitRunner
+            adb shell am instrument -w -e notClass io.github.maxlyth.hapaneld.shizuku.ShizukuIntegrationTest io.github.maxlyth.hapaneld.test/androidx.test.runner.AndroidJUnitRunner


### PR DESCRIPTION
The `reactivecircus/android-emulator-runner` script step executed the backslash-continued `am instrument` command as separate `sh -c` invocations per line instead of joining the continuation, so `-w` ran alone and then `-e notClass ...` was interpreted as flags to `sh` itself ("Illegal option -"). Every nightly run has failed since this workflow was introduced 2026-07-20.

The sibling `shizuku-emulator.yml` issues the identical command on one line and works, so collapse this one the same way.

## Test plan
- [ ] Re-run via workflow_dispatch and confirm the instrumentation step passes on both API 27 and API 35