### PR TITLE
test: fix stale step-name reference in shelly workflow injection test

### DIFF
--- a/tools/firmware-index/test_shelly_firmware.py
+++ b/tools/firmware-index/test_shelly_firmware.py
@@ -216,7 +216,7 @@ class ShellyFirmwareValidationTest(unittest.TestCase):
         workflow = pathlib.Path(__file__).parents[2] / ".github/workflows/shelly-firmware-monitor.yml"
         text = workflow.read_text()
         self.assertIn("NEW_VERSIONS: ${{ steps.probe.outputs.new_versions }}", text)
-        run_script = text.split("- name: Commit updated firmware index", 1)[1]
+        run_script = text.split("- name: Open/update pull request with the firmware index", 1)[1]
         self.assertNotIn('${{ steps.probe.outputs.new_versions }}', run_script.split("run: |", 1)[1])
         self.assertIn('if [ -n "$NEW_VERSIONS" ]', run_script)
 


### PR DESCRIPTION
test_workflow_does_not_interpolate_manifest_output_into_shell_source located its target step by name, and the step was renamed from 'Commit updated firmware index' to 'Open/update pull request with the firmware index' in #62 (the workflow switched from pushing straight to main to opening a PR). This currently fails the `build` check on every PR, including #64.

Updated the test to the new step name. The security assertions it makes (that `steps.probe.outputs.new_versions` is passed via env var rather than interpolated into shell source) are unchanged and still pass.

## Test plan
- [x] `python3 -m unittest test_shelly_firmware` — 14/14 pass