### PR TITLE
fix: verify the helper restarted during rollback instead of trusting start

### DIFF
--- a/helper/install-daemon.sh
+++ b/helper/install-daemon.sh
@@ -564,7 +564,9 @@ rollback_root_helper() {
         fi
         sync || exit 1
         if [ -f /system/bin/hapaneld-helper.hapaneld-manual-recovery ]; then
-          start hapaneld_helper 2>/dev/null || ( /system/bin/hapaneld-helper >/dev/null 2>&1 & )
+          start hapaneld_helper 2>/dev/null
+          /system/bin/hapaneld-helper --request PING >/dev/null 2>&1 ||
+            ( /system/bin/hapaneld-helper >/dev/null 2>&1 & )
           echo ROLLBACK_RESTARTED
         elif [ -f /data/adb/hapaneld/hapaneld-helper.hapaneld-manual-recovery ]; then
           /data/adb/hapaneld/hapaneld-helper >/dev/null 2>&1 &
@@ -657,7 +659,9 @@ rollback_root_helper() {
           /data/adb/hapaneld/hapaneld-helper >/dev/null 2>&1 &
           echo ROLLBACK_RESTARTED
         elif [ -x /system/bin/hapaneld-helper ]; then
-          start hapaneld_helper 2>/dev/null || ( /system/bin/hapaneld-helper >/dev/null 2>&1 & )
+          start hapaneld_helper 2>/dev/null
+          /system/bin/hapaneld-helper --request PING >/dev/null 2>&1 ||
+            ( /system/bin/hapaneld-helper >/dev/null 2>&1 & )
           echo ROLLBACK_RESTARTED
         elif [ -x /system/bin/hapaneld-ledd ]; then
           start hapaneld_ledd 2>/dev/null || ( /system/bin/hapaneld-ledd >/dev/null 2>&1 & )

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -2084,7 +2084,9 @@ rollback_system() {
   sync || return 1
 
   if [ -x /system/bin/hapaneld-helper ] && [ -f /system/bin/hapaneld-helper.hapaneld-recovery ]; then
-    start hapaneld_helper 2>/dev/null || /system/bin/hapaneld-helper >/dev/null 2>&1 &
+    start hapaneld_helper 2>/dev/null
+    /system/bin/hapaneld-helper --request PING >/dev/null 2>&1 ||
+      ( /system/bin/hapaneld-helper >/dev/null 2>&1 & )
     result=ROLLBACK_RESTARTED
   elif [ -x /data/adb/hapaneld/hapaneld-helper ] && [ -f /data/adb/hapaneld/hapaneld-helper.hapaneld-recovery ]; then
     /data/adb/hapaneld/hapaneld-helper >/dev/null 2>&1 &
@@ -2126,7 +2128,9 @@ rollback_systemless() {
     /data/adb/hapaneld/hapaneld-helper >/dev/null 2>&1 &
     result=ROLLBACK_RESTARTED
   elif [ -x /system/bin/hapaneld-helper ]; then
-    start hapaneld_helper 2>/dev/null || /system/bin/hapaneld-helper >/dev/null 2>&1 &
+    start hapaneld_helper 2>/dev/null
+    /system/bin/hapaneld-helper --request PING >/dev/null 2>&1 ||
+      ( /system/bin/hapaneld-helper >/dev/null 2>&1 & )
     result=ROLLBACK_RESTARTED
   elif [ -x /system/bin/hapaneld-ledd ]; then
     start hapaneld_ledd 2>/dev/null || /system/bin/hapaneld-ledd >/dev/null 2>&1 &
@@ -2181,7 +2185,9 @@ rollback_hybrid() {
     /data/adb/hapaneld/hapaneld-helper >/dev/null 2>&1 &
     result=ROLLBACK_RESTARTED
   elif [ -x /system/bin/hapaneld-helper ]; then
-    start hapaneld_helper 2>/dev/null || /system/bin/hapaneld-helper >/dev/null 2>&1 &
+    start hapaneld_helper 2>/dev/null
+    /system/bin/hapaneld-helper --request PING >/dev/null 2>&1 ||
+      ( /system/bin/hapaneld-helper >/dev/null 2>&1 & )
     result=ROLLBACK_RESTARTED
   elif [ -x /system/bin/hapaneld-ledd ]; then
     start hapaneld_ledd 2>/dev/null || /system/bin/hapaneld-ledd >/dev/null 2>&1 &


### PR DESCRIPTION
## Problem

`install-daemon.sh` already documents why `start` cannot be trusted on its own:

> A first-time init .rc is only loaded on the next boot on some vendor firmware, while `start` still exits successfully. Verify the socket and run the authenticated binary directly when init did not actually create the service process.

That reasoning was applied to the **install** paths, which now run `start`, probe with `--request PING`, and launch the authenticated binary directly if the probe fails.

The **rollback** paths were not updated. They still use:

```sh
start hapaneld_helper 2>/dev/null || ( /system/bin/hapaneld-helper >/dev/null 2>&1 & )
```

Since `start` exits 0 whether or not init knows the service, the `||` fallback never runs, and a rollback is exactly the situation where init does not know it yet — the `.rc` involved was written or restored during this boot.

Rollback stops and `pkill`s the running helper before restoring the previous binary. So when the fallback is skipped, the panel is left with **no helper process** even though the restored binary is on disk and executable. `rollback_root_helper()` then fails its `wait_for_helper_reply PING OK` check and reports *"rollback could not be verified … Restore the helper manually"*.

The reporting is honest — nothing claims false success — but a failure that was fully recoverable becomes a manual recovery, and the panel runs without its privileged helper until the next reboot re-registers the service.

## Change

Apply the existing start-then-verify sequence to the five rollback restart sites:

| File | Function |
| --- | --- |
| `scripts/provision.sh` | `rollback_system()`, `rollback_systemless()`, `rollback_hybrid()` |
| `helper/install-daemon.sh` | both `/system/bin` branches of `rollback_root_helper()` |

The `/data/adb/hapaneld/hapaneld-helper` branches already launch directly and are unchanged.

The legacy `hapaneld-ledd` branches are deliberately left alone — that binary predates the `--request` probe, so there is nothing to verify against. Happy to revisit if you would rather they were handled too.

## Testing

Hardware: **Sonoff NSPanel Pro 120P**, firmware `NSPanel120P_3.5.0`, Android 8.1.0 (API 27), rk3326, SuperSU `su` at `/system/xbin/su`, SELinux permissive.

Confirmed the premise directly on the panel:

```
start definitely_not_a_real_service_xyz ; echo $?   → 0
start hapaneld_helper ; echo $?                     → 0    (no such service installed)
```

and that nothing was started (`pidof hapaneld-helper` empty, `/system/bin/hapaneld-helper` absent). So on this firmware the old `||` fallback provably could not run.

Confirmed the probe is a valid discriminator on the same firmware — the v0.9.5 helper run from scratch storage answers:

```
HELPER version=1.1.0 proto=1.1
hapaneld-helper listening on abstract unix socket @hapaneld-helper
$ hapaneld-helper --request COMPANIONCAPS
COMPANIONCAPS 1 BACKUP RESTORE STATUS JOURNAL
```

byte-identical (no trailing `\r`) to the same probe on a panel running `NSPanel120P_3.8.0`.

### Limitations, stated plainly

- **I have not reproduced a live rollback with the patched code.** The failure that led me here was on the install path, which is already fixed in `main`; I found this by reading the rollback paths afterwards. The reasoning above is from the code plus the verified `start` behaviour, not from an observed patched-rollback recovery.
- The changed lines live inside the on-device transaction bodies, which the mock `adb` in `scripts/tests/provision_test.sh` does not execute — so no existing assertion covers them, and I did not find a practical way to add one within that harness. Suggestions welcome.
- `scripts/tests/provision_test.sh` cannot complete on macOS (it calls `/usr/bin/sha256sum`, and trips an empty-array expansion under bash 3.2). The 38 tests that do run pass identically with and without this change; I have relied on CI for the full suite.

## Context

Found while provisioning a 16-panel NSPanel Pro fleet. Two panels had never taken the large 3.8.0 OTA, so their `/system` had ~29 MB free rather than the usual ~12 KB, which routed them to the `system` install kind instead of `hybrid` — the path where the same `start` defect had bitten before it was fixed. Those two are the reason the `/system/bin` rollback branches are reachable at all in a modern fleet.
