### PR TITLE
fix: recover a broken mDNS advertiser instead of failing silently

### DIFF
--- a/app/src/main/kotlin/io/github/maxlyth/hapaneld/MdnsAdvertiser.kt
+++ b/app/src/main/kotlin/io/github/maxlyth/hapaneld/MdnsAdvertiser.kt
@@ -20,6 +20,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import javax.jmdns.JmDNS
@@ -48,6 +49,13 @@ class MdnsAdvertiser(
     @Volatile private var resolver: ThreadPoolExecutor? = null
     private val browseGeneration = AtomicLong()
     private val retirement = AtomicReference<CompletableFuture<Boolean>?>()
+    // The LAN address JmDNS is actually bound to. A panel's IPv4 arrives asynchronously (DHCP) and can
+    // change later, so this is compared against the live address on every [start] to catch a stale bind.
+    @Volatile private var boundIp: String? = null
+    // Set when the refresh sweep proves the responder died under a still-non-null JmDNS (see the sweep).
+    @Volatile private var responderDead = false
+    @Volatile private var selfMissedSweeps = 0
+    private val recovering = AtomicBoolean(false)
 
     private fun newResolver() = ThreadPoolExecutor(
         RESOLVE_WORKERS, RESOLVE_WORKERS, 0L, TimeUnit.MILLISECONDS,
@@ -111,10 +119,37 @@ class MdnsAdvertiser(
         if (existing == null || newHasName || !oldHasName) peerMap[p.panelId] = p
     }
 
-    /** Blocking network setup — call off the main thread. */
+    /**
+     * Blocking network setup — call off the main thread.
+     *
+     * Safe (and cheap) to call repeatedly: it revalidates an existing advertisement instead of assuming
+     * that a non-null JmDNS is a healthy one. A panel whose bind went stale or whose responder died is
+     * torn down and rebuilt here, because nothing else in the process ever notices — the HTTP API keeps
+     * serving the last known roster and the panel silently disappears from every other panel's switcher.
+     */
     fun start() {
         ownerGate.runIfOpen(Unit) start@{
-            if (jmdns != null) return@start
+            val lanIp = localIpv4()
+            if (lanIp == null) {
+                // No LAN IPv4 yet — ha-paneld starts before DHCP completes on a cold boot. Binding now
+                // would land on loopback: the panel would join the mDNS group on `lo`, advertise an
+                // unreachable 127.0.0.1 and never see a peer. Defer; the network callback re-runs this.
+                Log.i(TAG, "mDNS advertise deferred — no LAN IPv4 yet")
+                return@start
+            }
+            if (jmdns != null) {
+                // `browsing` false with a live JmDNS is the zombie a partially-drained stop() leaves
+                // behind: still advertising, but record() no-ops so the roster can never change again.
+                if (boundIp == lanIp && !responderDead && browsing) return@start // healthy — nothing to do
+                Log.w(
+                    TAG,
+                    "mDNS unhealthy (bound=$boundIp lan=$lanIp dead=$responderDead browsing=$browsing) — rebuilding",
+                )
+                stopResources(MonotonicDeadline(OWNER_STOP_MS))
+                // A teardown that could not drain leaves JmDNS owned by an in-flight call; retry later
+                // rather than stacking a second responder on the same port.
+                if (jmdns != null) return@start
+            }
             if (resolver?.isShutdown != false) resolver = newResolver()
             try {
                 val wifi = context.applicationContext
@@ -123,7 +158,7 @@ class MdnsAdvertiser(
                     setReferenceCounted(true)
                     acquire()
                 }
-                val addr = localAddress()
+                val addr = InetAddress.getByName(lanIp)
                 val dns = JmDNS.create(addr, runtimePanelId)
                 val props = mapOf(
                     "ver" to Config.VERSION,
@@ -142,6 +177,9 @@ class MdnsAdvertiser(
                     props,
                 )
                 jmdns = dns
+                boundIp = lanIp
+                responderDead = false
+                selfMissedSweeps = 0
                 dns.registerService(info)
                 // Start the persistent peer browse (powers the header switcher) — begins querying immediately
                 // and keeps the roster fresh in the background, so a UI read is instant + complete.
@@ -165,6 +203,22 @@ class MdnsAdvertiser(
                                 break
                             }
                             services.forEach { record(it, it.name ?: "") }
+                            // Liveness. A live JmDNS always lists THIS panel's own advertisement — it is
+                            // learned back over the same multicast path as any peer's. A JmDNS that was
+                            // closed (or whose socket died) keeps the object non-null while list() goes
+                            // empty, so without this the panel stays invisible to the whole fleet while
+                            // /api/v1/peers happily serves the frozen roster. Require several consecutive
+                            // misses so one congested sweep can't flap a healthy advertiser.
+                            selfMissedSweeps = nextMissedSweeps(
+                                selfMissedSweeps,
+                                services.any { (it.name ?: "") == runtimePanelId },
+                            )
+                            if (selfMissedSweeps >= DEAD_SWEEPS) {
+                                Log.w(TAG, "mDNS responder stopped listing this panel — rebuilding")
+                                responderDead = true
+                                requestRecovery()
+                                break
+                            }
                         } catch (failure: Exception) {
                             cost.outcome(FeatureCostOutcome.FAILURE)
                         } finally {
@@ -185,6 +239,54 @@ class MdnsAdvertiser(
 
     /** Stop the current advertisement while still allowing a later network-recovery restart. */
     fun stop() = ownerGate.runExclusive { stopResources(MonotonicDeadline(OWNER_STOP_MS)) }
+
+    /**
+     * Rebuild off the refresh thread. [stopResources] has to interrupt-and-join that thread, which
+     * refuses a self-join — so the sweep that detects the death must hand the restart to someone else
+     * or the teardown fails and the advertiser stays dead. Collapses to one in-flight recovery.
+     */
+    private fun requestRecovery() {
+        if (!recovering.compareAndSet(false, true)) return
+        Thread {
+            try {
+                runRecovery()
+            } catch (failure: Throwable) {
+                Log.w(TAG, "mDNS recovery failed", failure)
+            } finally {
+                recovering.set(false)
+            }
+        }.apply { isDaemon = true; name = "mdns-recover"; start() }
+    }
+
+    /** Retry the teardown+rebuild a few times: the detecting sweep has already exited, so a teardown that
+     *  loses its drain race here would otherwise leave the responder dead until the next network event. */
+    private fun runRecovery() {
+        repeat(RECOVERY_ATTEMPTS) { attempt ->
+            if (!ownerGate.isOpen()) return // retired — a late recovery must not resurrect this generation
+            ownerGate.runExclusive { stopResources(MonotonicDeadline(OWNER_STOP_MS)) }
+            start()
+            if (health().advertising) return
+            if (attempt < RECOVERY_ATTEMPTS - 1) {
+                try {
+                    Thread.sleep(RECOVERY_BACKOFF_MS)
+                } catch (_: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    return
+                }
+            }
+        }
+        // Still down: health() now reports it, so the status banner shows the panel has left the fleet,
+        // and the next network callback re-runs start().
+        Log.w(TAG, "mDNS recovery gave up after $RECOVERY_ATTEMPTS attempts")
+    }
+
+    /** Advertiser health for the status banner — see [mdnsHealthWarning]. Never throws. */
+    fun health(): MdnsHealth = MdnsHealth(
+        advertising = jmdns != null && browsing,
+        boundIp = boundIp,
+        lanIp = localIpv4(),
+        responderDead = responderDead,
+    )
 
     /** Permanently close this runtime generation so a late recovery callback cannot resurrect it. */
     internal fun retire(deadline: MonotonicDeadline): CompletableFuture<Boolean> {
@@ -225,6 +327,8 @@ class MdnsAdvertiser(
         runCatching { jmdns?.unregisterAllServices() }.onFailure { complete = false }
         runCatching { jmdns?.close() }.onFailure { complete = false }
         jmdns = null
+        boundIp = null
+        selfMissedSweeps = 0
         runCatching { lock?.release() }.onFailure { complete = false }
         lock = null
         return complete && deadline.remainingMs() > 0L
@@ -358,11 +462,6 @@ class MdnsAdvertiser(
             java.net.Socket().use { it.connect(java.net.InetSocketAddress(ip, port), timeoutMs) }; true
         }.getOrDefault(false)
 
-    // Bind JmDNS to the panel's real LAN address. The old WifiManager.connectionInfo path returns
-    // 0 on Ethernet panels (→ 127.0.0.1, which HA zeroconf can't reach), so enumerate interfaces.
-    private fun localAddress(): InetAddress =
-        localIpv4()?.let { InetAddress.getByName(it) } ?: InetAddress.getLocalHost()
-
     companion object {
         private const val TAG = "ha-paneld/mdns"
         private const val RESOLVE_MS = 2500L // per-peer mDNS resolve budget (off the JmDNS thread)
@@ -370,6 +469,9 @@ class MdnsAdvertiser(
         private const val RESOLVE_QUEUE = 32
         private const val MAX_PEERS = 64
         private const val REFRESH_MS = 60_000L // periodic re-browse interval (name refresh / gap fill)
+        private const val DEAD_SWEEPS = 3 // consecutive self-less sweeps before declaring JmDNS dead
+        private const val RECOVERY_ATTEMPTS = 3
+        private const val RECOVERY_BACKOFF_MS = 5_000L
         private const val LIST_MS = 3000L // dns.list resolve budget per refresh sweep
         private const val OWNER_STOP_MS = 2_000L
         private const val HA_SERVICE_TYPE = "_home-assistant._tcp.local."
@@ -388,6 +490,35 @@ internal fun safeAdvertisedHaUrl(raw: String?, serviceIps: Set<String>): String?
     if (serviceIps.isEmpty() || destinationIps.intersect(serviceIps).isEmpty()) return null
     return uri.toString().trimEnd('/')
 }
+
+/** Observable state of the mDNS advertiser. [boundIp] is the address JmDNS is bound to (null when it is
+ *  not advertising); [lanIp] is the panel's live LAN IPv4, also null before DHCP has handed one out. */
+data class MdnsHealth(
+    val advertising: Boolean,
+    val boundIp: String?,
+    val lanIp: String?,
+    val responderDead: Boolean,
+)
+
+/**
+ * Pure: the operator-facing warning for an unhealthy advertiser, or null when there is nothing to say.
+ * A silently dead responder is the whole failure class this guards — the panel keeps working over HTTP
+ * and keeps serving its last roster, so without a banner nobody notices it left the fleet switcher.
+ */
+internal fun mdnsHealthWarning(health: MdnsHealth): String? = when {
+    // No LAN address at all: the panel has bigger problems and every other card already says so.
+    health.lanIp == null -> null
+    !health.advertising || health.responderDead ->
+        "⚠ <b>Panel discovery (mDNS) is not running</b> — this panel is missing from other panels' " +
+            "switcher menus, and Home Assistant cannot auto-discover it. It retries automatically."
+    health.boundIp != health.lanIp ->
+        "⚠ <b>Panel discovery (mDNS) is advertising a stale address</b> (${health.boundIp}, now " +
+            "${health.lanIp}) — other panels cannot reach this one from their switcher until it rebinds."
+    else -> null
+}
+
+/** Pure: consecutive refresh sweeps that did not list this panel's own advertisement. */
+internal fun nextMissedSweeps(previous: Int, sawSelf: Boolean): Int = if (sawSelf) 0 else previous + 1
 
 internal fun mdnsRunCurrent(
     generation: AtomicLong,

--- a/app/src/main/kotlin/io/github/maxlyth/hapaneld/PaneldService.kt
+++ b/app/src/main/kotlin/io/github/maxlyth/hapaneld/PaneldService.kt
@@ -850,6 +850,8 @@ class PaneldService : Service() {
             // LAN ha-paneld peers over mDNS for the header panel switcher. Captures the `mdns` FIELD (not a
             // snapshot) so it follows reconfigure()'s reassignment; browsePeers null-guards the swap window.
             peers = { mdns.browsePeers() },
+            // Same live-field capture as `peers`: report the CURRENT advertiser's health, not a snapshot.
+            mdnsWarning = { mdnsHealthWarning(mdns.health()) },
             rendererPreparation = rendererPreparation,
             entityLearning = entityLearning,
             autoBrightnessHttpApi = adaptiveBrightnessHttpApi(),
@@ -937,6 +939,18 @@ class PaneldService : Service() {
             wifiDiagnostics = wifiDiagnostics::snapshot,
             learnedProximityEligibility = sensors::hasLearnedProximity,
         )
+    }
+
+    /**
+     * Re-check the mDNS advertiser against the current LAN address, off the callback thread.
+     *
+     * Deliberately NOT gated on the MQTT state the way [networkAvailableAction] gates MQTT's own
+     * recovery: mDNS breaks independently of MQTT (a boot-time bind before DHCP, an IP change, a dead
+     * responder), and a panel with healthy MQTT would otherwise never re-examine it. [MdnsAdvertiser.start]
+     * is a cheap no-op when the advertisement is already healthy, so this is safe to call on every event.
+     */
+    private fun revalidateMdns(observed: ServiceRuntimeOwner.Observation<NetworkRuntime>) {
+        runtime.reconnect(observed) { it.mdns.start() }
     }
 
     private fun buildMdns(identity: NetworkRuntimeIdentity): MdnsAdvertiser = MdnsAdvertiser(
@@ -2441,6 +2455,7 @@ class PaneldService : Service() {
                 val observed = runtime.observe() ?: return
                 val target = observed.value.mqtt
                 target.refreshDiscoveryAddress()
+                revalidateMdns(observed)
                 when (networkAvailableAction(target.state, target.configuredBroker)) {
                     NetworkAvailableAction.NONE -> Unit
                     NetworkAvailableAction.RECONNECT -> {
@@ -2458,7 +2473,11 @@ class PaneldService : Service() {
             }
 
             override fun onLinkPropertiesChanged(network: Network, linkProperties: LinkProperties) {
-                runtime.observe()?.value?.mqtt?.refreshDiscoveryAddress()
+                val observed = runtime.observe() ?: return
+                observed.value.mqtt.refreshDiscoveryAddress()
+                // The panel's IPv4 arriving (or changing) is exactly what strands the advertiser on a
+                // stale bind, so this is the event that matters most for mDNS.
+                revalidateMdns(observed)
             }
 
             override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {

--- a/app/src/main/kotlin/io/github/maxlyth/hapaneld/http/PaneldServer.kt
+++ b/app/src/main/kotlin/io/github/maxlyth/hapaneld/http/PaneldServer.kt
@@ -644,6 +644,10 @@ class PaneldServer internal constructor(
     // LAN ha-paneld peers discovered over mDNS — powers the header panel switcher. Injected by the service
     // (captures the live MdnsAdvertiser field). Blocking browse; called only through [peersCache] off-thread.
     private val peers: () -> List<io.github.maxlyth.hapaneld.Peer> = { emptyList() },
+    // Advertiser health for the status banner. A dead or stale-bound responder is otherwise invisible:
+    // the panel keeps serving its last known roster while it has silently left every other panel's
+    // switcher. Null when healthy (or when there is no LAN address to advertise in the first place).
+    private val mdnsWarning: () -> String? = { null },
     // Shared with the service startup path: serializes renderer config commit → atomic Companion borrow →
     // launch, and retries an interrupted built-in switch from its durable blank-URL state.
     private val rendererPreparation: RendererPreparationCoordinator,
@@ -2688,6 +2692,7 @@ publishes MQTT availability, so the discovery hooks are in place.</p>
         radio?.let { z ->
             zigbeeWarning(z)?.let(warns::add)
         }
+        runCatching(mdnsWarning).getOrNull()?.let(warns::add)
         warns.addAll(findings.map { statusWarning(it) })
         val capColor = mapOf("ok" to "#48c774", "degraded" to "#d9a528", "none" to "#d04a3b")
         // Stale-while-revalidate keeps status polling fast while ensuring a status-only client still

--- a/app/src/test/kotlin/io/github/maxlyth/hapaneld/MdnsHealthTest.kt
+++ b/app/src/test/kotlin/io/github/maxlyth/hapaneld/MdnsHealthTest.kt
@@ -1,0 +1,82 @@
+package io.github.maxlyth.hapaneld
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Advertiser health reporting — the decisions that keep a broken mDNS responder from failing silently.
+ *
+ * A panel whose JmDNS bound before DHCP (loopback), whose bind went stale after an address change, or
+ * whose responder died keeps answering HTTP and keeps serving its last known roster. Nothing else in the
+ * process notices, so these two pure helpers are what drive the rebuild and the operator-facing banner.
+ */
+class MdnsHealthTest {
+
+    private fun health(
+        advertising: Boolean = true,
+        boundIp: String? = "10.0.4.109",
+        lanIp: String? = "10.0.4.109",
+        responderDead: Boolean = false,
+    ) = MdnsHealth(advertising, boundIp, lanIp, responderDead)
+
+    // --- mdnsHealthWarning ---
+    @Test fun healthyAdvertiserWarnsAboutNothing() {
+        assertNull(mdnsHealthWarning(health()))
+    }
+
+    @Test fun noLanAddressIsNotAnMdnsWarning() {
+        // Before DHCP there is nothing to advertise; the panel's connectivity cards already cover it, and
+        // start() legitimately defers rather than binding loopback.
+        assertNull(mdnsHealthWarning(health(advertising = false, boundIp = null, lanIp = null)))
+    }
+
+    @Test fun stoppedResponderWarns() {
+        val warning = mdnsHealthWarning(health(advertising = false, boundIp = null))
+        assertNotNull(warning)
+        assertTrue(warning!!.contains("not running"))
+    }
+
+    @Test fun deadResponderWarnsEvenWhileJmdnsLooksPresent() {
+        // The exact failure that stranded panels: the object is still there, the roster still serves, but
+        // the responder is gone and the panel has silently left every other panel's switcher.
+        val warning = mdnsHealthWarning(health(advertising = true, responderDead = true))
+        assertNotNull(warning)
+        assertTrue(warning!!.contains("not running"))
+    }
+
+    @Test fun staleBindReportsBothAddresses() {
+        val warning = mdnsHealthWarning(health(boundIp = "127.0.0.1", lanIp = "10.0.4.109"))
+        assertNotNull(warning)
+        assertTrue(warning!!.contains("127.0.0.1"))
+        assertTrue(warning.contains("10.0.4.109"))
+    }
+
+    @Test fun aDeadResponderOutranksAStaleBind() {
+        // Both are true after a loopback bind is detected; the rebuild message is the useful one.
+        val warning = mdnsHealthWarning(health(boundIp = "127.0.0.1", responderDead = true))
+        assertTrue(warning!!.contains("not running"))
+    }
+
+    // --- nextMissedSweeps ---
+    @Test fun seeingSelfClearsTheMissStreak() {
+        assertEquals(0, nextMissedSweeps(previous = 2, sawSelf = true))
+        assertEquals(0, nextMissedSweeps(previous = 0, sawSelf = true))
+    }
+
+    @Test fun missingSelfAccumulates() {
+        assertEquals(1, nextMissedSweeps(previous = 0, sawSelf = false))
+        assertEquals(3, nextMissedSweeps(previous = 2, sawSelf = false))
+    }
+
+    @Test fun oneMissedSweepDoesNotCondemnAHealthyAdvertiser() {
+        // A congested sweep (whole-fleet restart) must not flap a working responder: the streak has to
+        // survive a single miss, which is why the rebuild threshold is several consecutive sweeps.
+        var streak = 0
+        streak = nextMissedSweeps(streak, sawSelf = false)
+        streak = nextMissedSweeps(streak, sawSelf = true)
+        assertEquals(0, streak)
+    }
+}


### PR DESCRIPTION
## The problem

On a 16-panel fleet, 7 panels were missing from every panel's header switcher while remaining fully reachable at `http://<ip>:8888`. The dropdown showed a consistent 9 panels on the 9 healthy ones.

It is not a network or multicast problem: all 16 panels are on the same VLAN and SSID, and the failures do not correlate with access point, radio channel or signal. The mDNS responder inside ha-paneld was broken on those 7 panels, in two distinct ways, and nothing in the process ever detected or repaired it.

## Evidence

Kernel multicast group membership (`/proc/net/igmp`, group `FB0000E0` = 224.0.0.251) and the UDP 5353 socket table split the fleet into exactly three cohorts, matching the observed rosters:

| Cohort | Panels | app socket on :5353 | mDNS group joined on | self-advertised IP | own roster |
|---|---|---|---|---|---|
| Healthy | 9 | yes | `wlan0` (Users=2) | correct | 9 — all healthy peers |
| Loopback-bound | 4 | yes | **`lo`** (Users=1) | **`127.0.0.1`** | 1 (itself) |
| Dead responder | 3 | **absent** | none (Users=1 = system `mdnsd` only) | correct | 7–9, stale |

On a healthy panel the group is joined on `wlan0` with two members (Android's own `mdnsd` plus ha-paneld's JmDNS). On the loopback cohort the JmDNS membership sits on `lo` instead. On the dead cohort ha-paneld has no socket on 5353 at all, yet `/api/v1/peers` still served a roster — a frozen `peerMap` snapshot from before the responder died, with nothing indicating discovery had stopped.

All 16 panels had restarted ha-paneld at roughly the same time ~28 h earlier; none had recovered.

## Root causes

**1. Loopback bind.** `localAddress()` fell back to `InetAddress.getLocalHost()` when `localIpv4()` returned null, which is exactly what happens when ha-paneld starts before DHCP completes on a cold boot. JmDNS then binds there, joins 224.0.0.251 on `lo`, and publishes an A record of `127.0.0.1` — invisible to peers and unable to see them. `wlan0` had held a valid address for many hours by the time this was observed; the bind was simply never revisited.

**2. Dead responder.** JmDNS was gone while the field reference stayed non-null, so the advertiser looked "started" to every caller.

**Why neither recovered.** Two things combine:

- `start()` returned early whenever `jmdns != null` — idempotent by nullity, not by health. A loopback-bound instance is still "started".
- The only post-boot callers of `mdns.start()` are gated on the MQTT state being `discovering` (`networkAvailableAction` returns `NONE` for `connected`). Every affected panel had healthy MQTT, so the recovery path never fired.

There is also no periodic liveness check, and `/api/v1/status` reported no warning — a panel advertising itself as `127.0.0.1` had an empty `warnings` array.

## The change

- **Drop the loopback fallback.** `start()` reads `localIpv4()` first and defers when it is null rather than binding `getLocalHost()`. A cold boot that beats DHCP no longer produces a permanently loopback-bound responder.
- **Make `start()` revalidate rather than short-circuit.** It rebuilds when the bind address no longer matches the live LAN IPv4, when the responder is known dead, or when `browsing` is false with a live JmDNS — the zombie state a partially-drained `stop()` leaves behind, where `record()` no-ops and the roster can never change again.
- **Add a liveness probe to the existing 60 s refresh sweep.** A live JmDNS always lists this panel's own advertisement, since it is learned back over the same multicast path as any peer's; a closed one keeps the object non-null while `list()` goes empty. Three consecutive self-less sweeps trigger a bounded rebuild. The rebuild runs on a separate thread because `stopResources()` must interrupt-and-join the refresh thread, and `interruptAndJoin` refuses a self-join — the detecting sweep cannot drive its own restart. Recovery is capped at 3 attempts with backoff and will not resurrect a retired generation.
- **Revalidate mDNS on `onAvailable` and `onLinkPropertiesChanged`, independent of the MQTT state.** mDNS breaks independently of MQTT, and an address arriving or changing is precisely what strands the bind. `networkAvailableAction` is untouched and still governs MQTT only.
- **Surface the failure.** `/api/v1/status` now warns on a stopped/dead responder or a stale bind, so this cannot fail silently again.

## Testing

Done:

- `:app:testDebugUnitTest` — 2126 tests, 0 failures, including 9 new ones in `MdnsHealthTest` covering the health-warning decisions and the miss-streak logic.
- `:app:lintDebug` — clean.
- `:app:assembleDebug` — builds.
- Diagnosis above was gathered from a live 16-panel fleet (NSPanel Pro, `rockchip px30_evb`, firmware `NSPanel120P_3.8.0` / 3.8.0, Android 8.1.0 API 27, ha-paneld 0.9.5).

Not yet done — and this is the reason for the request below:

- **No on-panel validation of the fix.** The fleet runs the release-signed APK, and a locally built debug APK cannot update it in place. Installing one means uninstalling first, which discards learned entity state and history, the profile catalog and the Companion login (per `docs/provisioning.md`). That is not a reasonable trade for validating a fix on a live installation.
- Untested: Ethernet/SMT1019 panels, API levels other than 27, and the liveness-probe path (JmDNS cannot easily be killed on demand — it would be observed in a soak rather than triggered).

**Request:** if this looks reasonable, could it go into an RC? A release-signed RC installs in place with no data loss, and the fleet above is a good test bed — it currently contains panels in both broken states. I would then verify:

- no regression on a healthy panel,
- a deliberately reproduced boot race (Wi-Fi down, restart, Wi-Fi up) recovering instead of stranding on `127.0.0.1`,
- rebind after an address change,
- fleet-wide convergence to identical 16-entry rosters,
- a 48 h soak checking specifically for false-positive rebuilds on healthy panels.

Happy to report those results back here, and to adjust the approach — particularly the liveness heuristic and the `DEAD_SWEEPS`/backoff constants, which are judgement calls rather than anything derived.

## Notes

- One behaviour change worth flagging: with no LAN IPv4, the panel now advertises nothing instead of advertising loopback. That is intended — a loopback advertisement is strictly worse than none, and it also removes an unreachable `127.0.0.1` record from HA zeroconf.
- The comment removed with `localAddress()` noted that the old `WifiManager.connectionInfo` path returned 0 on Ethernet panels and fell through to `127.0.0.1`. That concern is preserved: `localIpv4()` still enumerates interfaces and works for both Wi-Fi and Ethernet; only the loopback fallback is gone.
