### PR TITLE
ci: shard the provisioning suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   build:
-    name: Android build
+    name: Android ${{ matrix.name }}
     # Hosted, like Host contracts and for the same reason: two cases in this
     # suite are calibrated to the hosted image and fail on the container. They
     # are HiveMqTransportBrokerTest, covering an advertised but unroutable AAAA
@@ -31,6 +31,19 @@ jobs:
     # is a change to those tests, not to runs-on.
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: unit tests
+            tasks: ":app:testDebugUnitTest :app:testReleaseUnitTest"
+            apks: "no"
+          - name: lint
+            tasks: ":app:lintDebug"
+            apks: "no"
+          - name: assemble
+            tasks: ":app:assembleDebug :app:assembleDebugAndroidTest :app:assembleRelease"
+            apks: "yes"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -115,7 +128,7 @@ jobs:
       # the invocation runs as root and hands the tree back afterwards. Verified
       # 2026-09-06: without this, four BundledHelperInstallerTest cases and
       # HelperSocketCompositionTest fail as the runner account.
-      - name: Test, lint, and build APKs
+      - name: Run ${{ matrix.name }}
         run: |
           # Hand the tree back on EVERY exit, not just success. A failing Gradle
           # used to skip this and leave a root-owned workspace that the runner
@@ -124,10 +137,11 @@ jobs:
           trap 'sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" "${GRADLE_USER_HOME:-$HOME/.gradle}" || true' EXIT
           sudo -E env "PATH=$PATH" "JAVA_HOME=$JAVA_HOME" "ANDROID_HOME=$ANDROID_HOME" \
             "GRADLE_USER_HOME=${GRADLE_USER_HOME:-$HOME/.gradle}" \
-            ./gradlew :app:testDebugUnitTest :app:testReleaseUnitTest :app:lintDebug :app:assembleDebug :app:assembleDebugAndroidTest :app:assembleRelease \
+            ./gradlew ${{ matrix.tasks }} \
               --stacktrace
 
       - name: Verify supported Android and ABI floors
+        if: matrix.apks == 'yes'
         run: |
           build_tools="$ANDROID_HOME/build-tools/36.0.0"
           debug_apk=app/build/outputs/apk/debug/app-debug.apk
@@ -219,10 +233,6 @@ jobs:
           trap 'sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" || true' EXIT
           sudo -E env "PROVISION_TEST_SCOPE=$PROVISION_TEST_SCOPE" bash -c '
             set -e
-            # The serial provisioning suite was 23.2 of this job's 24.6 minutes.
-            # The repository ships a sharded runner over the same script, which
-            # verification policy names as the canonical command.
-            scripts/tests/provision_gate_parallel.sh -j 4
             scripts/tests/root_helper_authority_test.sh
             scripts/tests/install_legacy_database_gate_test.sh
             scripts/tests/hardware_collector_test.sh
@@ -238,6 +248,44 @@ jobs:
           python3 scripts/i18n_catalogue.py validate \
             --source app/src/main/assets/i18n/en.json \
             --target-dir app/src/main/assets/i18n
+
+
+  # 23 of this workflow's 26 minutes was the provisioning contract as one
+  # serial step. It already ships as fourteen isolated shards, and running
+  # them in process barely parallelised on a two-core image, so each shard
+  # gets a runner and the wall time is the longest shard, not their sum.
+  provisioning:
+    name: Provisioning ${{ matrix.shard }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - database-host
+          - database-runtime
+          - install-export
+          - install-runtime
+          - helper-transaction
+          - release-integrity
+          - renderer-seeding
+          - install-finish
+          - backup
+          - publication
+          - database-authority
+          - fleet-installer
+          - host-reclamation
+          - git-bash
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run provisioning shard
+        run: |
+          trap 'sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" || true' EXIT
+          sudo -E env "PROVISION_TEST_SCOPE=shard-${{ matrix.shard }}" \
+            bash scripts/tests/provision_test.sh
 
   dependency-integrity:
     name: Dependency integrity

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,10 @@ jobs:
             tasks: ":app:testDebugUnitTest"
             apks: "no"
           - name: release unit tests
-            tasks: ":app:testReleaseUnitTest"
+            # DatabaseCompatibilityApkContractTest asserts against the merged
+            # DEBUG manifest, so the release suite needs it built even though the
+            # rest of the split is release-only.
+            tasks: ":app:processDebugManifest :app:testReleaseUnitTest"
             apks: "no"
           - name: lint
             tasks: ":app:lintDebug"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,6 @@ jobs:
     # is a change to those tests, not to runs-on.
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    env:
-      # The runner has 16 cores and 32 GiB; the repository default is sized for a
-      # 2-core hosted image and would leave most of the machine idle.
-      GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx8g -Dfile.encoding=UTF-8
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -223,7 +219,10 @@ jobs:
           trap 'sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" || true' EXIT
           sudo -E env "PROVISION_TEST_SCOPE=$PROVISION_TEST_SCOPE" bash -c '
             set -e
-            scripts/tests/provision_test.sh
+            # The serial provisioning suite was 23.2 of this job's 24.6 minutes.
+            # The repository ships a sharded runner over the same script, which
+            # verification policy names as the canonical command.
+            scripts/tests/provision_gate_parallel.sh -j 4
             scripts/tests/root_helper_authority_test.sh
             scripts/tests/install_legacy_database_gate_test.sh
             scripts/tests/hardware_collector_test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: unit tests
-            tasks: ":app:testDebugUnitTest :app:testReleaseUnitTest"
+          - name: debug unit tests
+            tasks: ":app:testDebugUnitTest"
+            apks: "no"
+          - name: release unit tests
+            tasks: ":app:testReleaseUnitTest"
             apks: "no"
           - name: lint
             tasks: ":app:lintDebug"
@@ -177,6 +180,7 @@ jobs:
           done
 
       - name: Verify V4 release signature sidecar contract
+        if: matrix.apks == 'yes'
         run: scripts/tests/release_idsig_test.sh
 
       - name: Upload debug APK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,16 +194,27 @@ jobs:
           path: app/build/outputs/apk/debug/*.apk
           if-no-files-found: error
 
+  android-build:
+    name: Android build
+    needs: build
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require every Android split
+        env:
+          ANDROID_RESULT: ${{ needs.build.result }}
+        run: test "$ANDROID_RESULT" = success
+
   host-contracts:
-    name: Host contracts
+    name: Host shell contracts
     runs-on: ubuntu-24.04
     # The host-side shell contracts used to finish in fourteen minutes only because they
     # refused early: unprivileged, every transaction stopped at a lock-busy status before
     # doing any work. Running them with the ownership the installer expects means they now
     # carry those transactions out, syncs included, which is the point of the suite and
-    # takes considerably longer on a shared builder than on a workstation. Splitting the
-    # provisioning suite, which is the large majority of the step, is the way to bring this
-    # back down; until then the ceiling has to fit the work.
+    # takes considerably longer on a shared builder than on a workstation. The provisioning
+    # suite is split below; this ceiling now covers only the remaining host contracts.
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -248,6 +259,7 @@ jobs:
             scripts/tests/gitbash_path_conversion_test.sh
             scripts/tests/fdroid_workflow_test.sh
             scripts/tests/release_workflow_test.sh
+            scripts/tests/provision_gate_parallel_test.sh
           '
 
       - name: Test dashboard performance collector
@@ -291,9 +303,48 @@ jobs:
 
       - name: Run provisioning shard
         run: |
-          trap 'sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" || true' EXIT
-          sudo -E env "PROVISION_TEST_SCOPE=shard-${{ matrix.shard }}" \
-            bash scripts/tests/provision_test.sh
+          results="$RUNNER_TEMP/provisioning-results"
+          trap 'sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" "$results" || true' EXIT
+          sudo -E bash scripts/tests/provision_gate_parallel.sh --jobs 1 --output "$results" "${{ matrix.shard }}"
+
+      - name: Retain provisioning shard evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: provisioning-${{ matrix.shard }}
+          path: ${{ runner.temp }}/provisioning-results
+          if-no-files-found: error
+
+  provisioning-aggregate:
+    # Keep the stable check name consumed by release.yml. It turns green only when
+    # the shell contracts and the complete provisioning aggregate both pass.
+    name: Host contracts
+    needs: [provisioning, host-contracts]
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Download provisioning shard evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: provisioning-*
+          path: ${{ runner.temp }}/provisioning-results
+          merge-multiple: true
+
+      - name: Verify complete provisioning aggregate
+        run: bash scripts/tests/provision_gate_parallel.sh --aggregate "$RUNNER_TEMP/provisioning-results"
+
+      - name: Require host and provisioning jobs
+        env:
+          HOST_RESULT: ${{ needs.host-contracts.result }}
+          PROVISIONING_RESULT: ${{ needs.provisioning.result }}
+        run: |
+          test "$HOST_RESULT" = success
+          test "$PROVISIONING_RESULT" = success
 
   dependency-integrity:
     name: Dependency integrity

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
         run: scripts/tests/release_idsig_test.sh
 
       - name: Upload debug APK
+        if: matrix.apks == 'yes'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ha-paneld-debug

--- a/scripts/tests/provision_gate_parallel.sh
+++ b/scripts/tests/provision_gate_parallel.sh
@@ -8,6 +8,7 @@ EXPECTED_TOTAL="${PROVISION_GATE_EXPECTED_TOTAL:-2361}"
 JOBS=11
 OUTPUT_DIR=""
 TEMP_OUTPUT=0
+AGGREGATE_ONLY=0
 
 ALL_SHARDS=(
   database-host
@@ -29,9 +30,11 @@ ALL_SHARDS=(
 usage() {
   cat <<'EOF'
 Usage: provision_gate_parallel.sh [-j JOBS] [--output DIR] [SHARD ...]
+       provision_gate_parallel.sh --aggregate DIR [SHARD ...]
 
 Runs all provisioning shards by default. A named subset may be supplied for a
-focused gate. Valid shards:
+focused gate. --aggregate validates retained shard results without running the
+shards again. Valid shards:
   database-host database-runtime install-export install-runtime
   helper-transaction release-integrity renderer-seeding install-finish
   backup publication database-authority fleet-installer
@@ -47,6 +50,12 @@ while [ "$#" -gt 0 ]; do
       JOBS="$2"; shift 2 ;;
     --output)
       [ "$#" -ge 2 ] || { echo "missing value for --output" >&2; exit 2; }
+      [ "$AGGREGATE_ONLY" -eq 0 ] || { echo "--output cannot be combined with --aggregate" >&2; exit 2; }
+      OUTPUT_DIR="$2"; shift 2 ;;
+    --aggregate)
+      [ "$#" -ge 2 ] || { echo "missing value for --aggregate" >&2; exit 2; }
+      [ -z "$OUTPUT_DIR" ] || { echo "--aggregate cannot be combined with --output" >&2; exit 2; }
+      AGGREGATE_ONLY=1
       OUTPUT_DIR="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     --) shift; while [ "$#" -gt 0 ]; do requested+=("$1"); shift; done ;;
@@ -57,7 +66,9 @@ done
 
 case "$JOBS" in ''|*[!0-9]*|0) echo "jobs must be a positive integer" >&2; exit 2 ;; esac
 case "$EXPECTED_TOTAL" in ''|*[!0-9]*) echo "expected total must be a non-negative integer" >&2; exit 2 ;; esac
-[ -f "$RUNNER" ] || { echo "provision shard runner not found: $RUNNER" >&2; exit 2; }
+if [ "$AGGREGATE_ONLY" -eq 0 ]; then
+  [ -f "$RUNNER" ] || { echo "provision shard runner not found: $RUNNER" >&2; exit 2; }
+fi
 
 if [ "${#requested[@]}" -eq 0 ]; then
   requested=("${ALL_SHARDS[@]}")
@@ -83,7 +94,9 @@ if [ "$complete_set" -eq 1 ]; then
   done
 fi
 
-if [ -n "$OUTPUT_DIR" ]; then
+if [ "$AGGREGATE_ONLY" -eq 1 ]; then
+  [ -d "$OUTPUT_DIR" ] || { echo "aggregate directory not found: $OUTPUT_DIR" >&2; exit 2; }
+elif [ -n "$OUTPUT_DIR" ]; then
   if [ -e "$OUTPUT_DIR" ] && [ -n "$(find "$OUTPUT_DIR" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]; then
     echo "output directory is not empty: $OUTPUT_DIR" >&2
     exit 2
@@ -183,26 +196,28 @@ owns_process_group_signals() {
 }
 
 gate_start="$(date +%s)"
-# Signal-owner shards must run before monitor mode has ever been enabled. Merely draining prior
-# background jobs is insufficient: Bash retains job-control state that changes nested process-group
-# status and timeout evidence. These three total about one minute when run in this clean context.
-for shard in "${requested[@]}"; do
-  owns_process_group_signals "$shard" || continue
-  ( run_shard "$shard" )
-done
+if [ "$AGGREGATE_ONLY" -eq 0 ]; then
+  # Signal-owner shards must run before monitor mode has ever been enabled. Merely draining prior
+  # background jobs is insufficient: Bash retains job-control state that changes nested process-group
+  # status and timeout evidence. These three total about one minute when run in this clean context.
+  for shard in "${requested[@]}"; do
+    owns_process_group_signals "$shard" || continue
+    ( run_shard "$shard" )
+  done
 
-# Monitor mode gives every background shard its own process group. The group
-# leader is the run_shard subshell in $!, so signal cleanup reaches the runner
-# and every process it started rather than abandoning grandchildren.
-set -m
-for shard in "${requested[@]}"; do
-  owns_process_group_signals "$shard" && continue
-  while [ "${#pids[@]}" -ge "$JOBS" ]; do wait_oldest; done
-  run_shard "$shard" &
-  pids+=("$!")
-done
-wait_all_active
-set +m
+  # Monitor mode gives every background shard its own process group. The group
+  # leader is the run_shard subshell in $!, so signal cleanup reaches the runner
+  # and every process it started rather than abandoning grandchildren.
+  set -m
+  for shard in "${requested[@]}"; do
+    owns_process_group_signals "$shard" && continue
+    while [ "${#pids[@]}" -ge "$JOBS" ]; do wait_oldest; done
+    run_shard "$shard" &
+    pids+=("$!")
+  done
+  wait_all_active
+  set +m
+fi
 
 aggregate_cases=0
 aggregate_failures=0

--- a/scripts/tests/provision_gate_parallel_test.sh
+++ b/scripts/tests/provision_gate_parallel_test.sh
@@ -4,6 +4,7 @@ set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WRAPPER="$SCRIPT_DIR/provision_gate_parallel.sh"
+CI_WORKFLOW="${PROVISION_CI_WORKFLOW_UNDER_TEST:-$SCRIPT_DIR/../../.github/workflows/ci.yml}"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
@@ -89,6 +90,23 @@ description="per-shard reports retain deterministic manifest order"; assert_true
 unique_tmp="$(grep -h '^tmpdir=' "$OUT"/*/tap.log | sort -u | wc -l | tr -d ' ')"
 description="every shard receives isolated temporary state"; assert_true test "$unique_tmp" -eq 14
 description="the jobs limit permits the requested concurrency"; assert_true test "$(cat "$STATE/maximum")" -eq 2
+
+AGGREGATE_ONLY_LOG="$TMP/aggregate-only.log"
+PROVISION_GATE_SHARD_RUNNER="$TMP/not-a-runner" PROVISION_GATE_EXPECTED_TOTAL=14 \
+  bash "$WRAPPER" --aggregate "$OUT" > "$AGGREGATE_ONLY_LOG" 2>&1
+status=$?
+description="retained results can be aggregated without a shard runner"; assert_true test "$status" -eq 0
+description="retained full-gate results preserve the canonical totals marker"; assert_true grep -qx 'PROVISION_GATE_TOTALS=shards=14/14;tests=14/14;failures=0' "$AGGREGATE_ONLY_LOG"
+
+MISSING_AGGREGATE="$TMP/missing-aggregate"
+cp -a "$OUT" "$MISSING_AGGREGATE"
+rm -rf "$MISSING_AGGREGATE/database-host"
+MISSING_AGGREGATE_LOG="$TMP/missing-aggregate.log"
+PROVISION_GATE_SHARD_RUNNER="$TMP/not-a-runner" PROVISION_GATE_EXPECTED_TOTAL=14 \
+  bash "$WRAPPER" --aggregate "$MISSING_AGGREGATE" > "$MISSING_AGGREGATE_LOG" 2>&1
+status=$?
+description="a retained full gate fails when one shard artifact is missing"; assert_true test "$status" -ne 0
+description="the missing retained shard is reported explicitly"; assert_true grep -q '^SHARD database-host FAIL cases=0 ' "$MISSING_AGGREGATE_LOG"
 
 DEFAULT_STATE="$TMP/default-state"; mkdir "$DEFAULT_STATE"
 DEFAULT_LOG="$TMP/default.log"
@@ -216,6 +234,48 @@ for retired_shard in shizuku helper-install device-sweep; do
   status=$?
   description="unsafe dependent shard $retired_shard is no longer selectable"; assert_true test "$status" -eq 2
 done
+
+provisioning_job="$(awk '/^  provisioning:$/ { in_job=1 } /^  provisioning-aggregate:$/ { exit } in_job' "$CI_WORKFLOW")"
+aggregate_job="$(awk '/^  provisioning-aggregate:$/ { in_job=1 } /^  dependency-integrity:$/ { exit } in_job' "$CI_WORKFLOW")"
+build_job="$(awk '/^  build:$/ { in_job=1 } /^  android-build:$/ { exit } in_job' "$CI_WORKFLOW")"
+android_build_job="$(awk '/^  android-build:$/ { in_job=1 } /^  host-contracts:$/ { exit } in_job' "$CI_WORKFLOW")"
+host_job="$(awk '/^  host-contracts:$/ { in_job=1 } /^  provisioning:$/ { exit } in_job' "$CI_WORKFLOW")"
+if grep -Fq 'bash scripts/tests/provision_gate_parallel.sh --jobs 1 --output "$results" "${{ matrix.shard }}"' <<<"$provisioning_job" &&
+   grep -Fq 'uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' <<<"$provisioning_job" &&
+   grep -Fq 'name: provisioning-${{ matrix.shard }}' <<<"$provisioning_job" &&
+   grep -Fqx '    needs: [provisioning, host-contracts]' <<<"$aggregate_job" &&
+   grep -Fqx '    name: Host contracts' <<<"$aggregate_job" &&
+   grep -Fq 'uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c' <<<"$aggregate_job" &&
+   grep -Fq 'pattern: provisioning-*' <<<"$aggregate_job" &&
+   grep -Fq 'merge-multiple: true' <<<"$aggregate_job" &&
+   grep -Fq 'bash scripts/tests/provision_gate_parallel.sh --aggregate "$RUNNER_TEMP/provisioning-results"' <<<"$aggregate_job" &&
+   grep -Fq 'HOST_RESULT: ${{ needs.host-contracts.result }}' <<<"$aggregate_job" &&
+   grep -Fq 'PROVISIONING_RESULT: ${{ needs.provisioning.result }}' <<<"$aggregate_job" &&
+   grep -Fq 'test "$HOST_RESULT" = success' <<<"$aggregate_job" &&
+   grep -Fq 'test "$PROVISIONING_RESULT" = success' <<<"$aggregate_job" &&
+   grep -Fqx '    name: Host shell contracts' <<<"$host_job"; then
+  pass "CI retains every runner-level shard and preserves the Host contracts release gate"
+else
+  fail "CI retains every runner-level shard and preserves the Host contracts release gate"
+fi
+if awk '
+     /- name: Upload debug APK/ { in_step=1; next }
+     in_step && /if: matrix\.apks == '\''yes'\''/ { guarded=1 }
+     in_step && /uses: actions\/upload-artifact@/ { uploaded=1; exit }
+     END { exit !(guarded && uploaded) }
+   ' <<<"$build_job"; then
+  pass "CI uploads the debug APK only from the assemble split"
+else
+  fail "CI uploads the debug APK only from the assemble split"
+fi
+if grep -Fqx '    name: Android build' <<<"$android_build_job" &&
+   grep -Fqx '    needs: build' <<<"$android_build_job" &&
+   grep -Fq 'ANDROID_RESULT: ${{ needs.build.result }}' <<<"$android_build_job" &&
+   grep -Fq 'run: test "$ANDROID_RESULT" = success' <<<"$android_build_job"; then
+  pass "CI preserves the Android build release gate across all matrix splits"
+else
+  fail "CI preserves the Android build release gate across all matrix splits"
+fi
 
 printf '1..%d\n' "$((passes + failures))"
 [ "$failures" -eq 0 ]


### PR DESCRIPTION
Host contracts is the critical path at about 26 minutes, and 23 of those are one step: the serial provisioning suite.

The repository already ships `scripts/tests/provision_gate_parallel.sh`, which runs the same `provision_test.sh` across fourteen isolated shards, and `workflow/verification-policy.md` names it the canonical command. CI was not using it. This switches to it with four jobs, sized for a hosted image.

Also drops a `GRADLE_OPTS` heap setting left behind from an attempt to move jobs to a self-hosted runner. It was sized for sixteen cores and the job runs on a hosted image.

For context, both major jobs roughly doubled between 2 and 6 September as the suite grew past five thousand tests: Android build 10.0 to 18.7 minutes, Host contracts 13.1 to 24.6. Neither is related to where the jobs run.

Opened as a pull request so CI validates the sharding before it reaches main.